### PR TITLE
Actual JSON sent by RapidSMS is one level deeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Ready to run in production? Please [check our deployment guides](https://hexdocs
 
 We use [pre-commit](https://pre-commit.com/) to format and test our code.
 
+To run a fake SMPP server (MC), we're currently using this docker image:
+
+```
+docker run -p 2775:2775 -p 88:88 --name smppsim kk1983/smpp
+```
+
 ## Learn more
 
   * Official website: http://www.phoenixframework.org/

--- a/lib/voomex_web/controllers/sms_controller.ex
+++ b/lib/voomex_web/controllers/sms_controller.ex
@@ -3,8 +3,9 @@ defmodule VoomexWeb.SMSController do
 
   alias Voomex.SMPP
 
-  def send(conn, %{"data" => %{"to_addr" => to_addr, "content" => content}})
+  def send(conn, %{"to_addr" => to_addr, "content" => content})
       when is_list(to_addr) do
+    # TODO: may also need "in_reply_to" and "metadata.rapidsms_msg_id"
     SMPP.send_to_mno(to_addr, content)
 
     json(conn, :ok)

--- a/test/voomex_web/controllers/sms_controller_test.exs
+++ b/test/voomex_web/controllers/sms_controller_test.exs
@@ -8,7 +8,7 @@ defmodule VoomexWeb.SMSControllerTest do
         "content" => "Hello, world"
       }
 
-      conn = post(conn, Routes.sms_path(conn, :send), data: data)
+      conn = post(conn, Routes.sms_path(conn, :send), data)
 
       assert json_response(conn, 200) == "ok"
 
@@ -21,13 +21,13 @@ defmodule VoomexWeb.SMSControllerTest do
         "content" => "Hello, world"
       }
 
-      conn = post(conn, Routes.sms_path(conn, :send), data: data)
+      conn = post(conn, Routes.sms_path(conn, :send), data)
 
       assert json_response(conn, 422) == "error"
     end
 
     test "failure when missing parameters", %{conn: conn} do
-      conn = post(conn, Routes.sms_path(conn, :send), data: %{})
+      conn = post(conn, Routes.sms_path(conn, :send), %{})
 
       assert json_response(conn, 422) == "error"
     end


### PR DESCRIPTION
I thought it was `data: {...}` but it's just `{...}`