### PR TITLE
Allow local dev customization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,15 @@ jobs:
   build:
     parallelism: 1
     docker:
-      - image: circleci/elixir:1.9.1
+      - image: circleci/elixir:1.10.3
         environment:
           MIX_ENV: test
+          DATABASE_URL: postgres://voomex@localhost/voomex_test
+      - image: circleci/postgres:10.12
+        environment:
+          POSTGRES_USER: voomex
+          POSTGRES_DB: voomex_test
+          POSTGRES_PASSWORD:
     working_directory: ~/app
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 To start your Phoenix server:
 
+  * Complete local dev setup (see below)
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.setup`
   * Install Node.js dependencies with `cd assets && npm install`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`
+  * Create and migrate your database with `mix ecto.setup`
   * Install Node.js dependencies with `cd assets && npm install`
   * Start Phoenix endpoint with `mix phx.server`
 
@@ -12,7 +13,7 @@ Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
 Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
 
-## Development
+## Local dev setup
 
 We use [pre-commit](https://pre-commit.com/) to format and test our code.
 
@@ -20,6 +21,28 @@ To run a fake SMPP server (MC), we're currently using this docker image:
 
 ```
 docker run -p 2775:2775 -p 88:88 --name smppsim kk1983/smpp
+```
+To stop and restart it, use these commands:
+
+```
+docker stop smppsim && docker start -a smppsim
+```
+
+The steps above should get you running. You can also make local configurations which won't go into
+version control. As an example, if you want the app to connect to Postgresql via unix domain
+sockets, add this to `config/dev.secret.exs`:
+
+```
+import Config
+
+config :voomex, Voomex.Repo,
+  socket_dir: "/var/run/postgresql",
+```
+
+To run the Phoenix server, while also having a command line to inspect stuff:
+
+```
+iex -S mix phx.server
 ```
 
 ## Learn more

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -69,3 +69,7 @@ config :phoenix, :stacktrace_depth, 20
 
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
+
+if File.exists?("config/#{Mix.env()}.secret.exs") do
+  import_config("#{Mix.env()}.secret.exs")
+end

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -16,7 +16,7 @@ secret_key_base =
 live_view_salt =
   System.get_env("LIVE_VIEW_SALT") ||
     raise """
-    environment variable SECRET_KEY_BASE is missing.
+    environment variable LIVE_VIEW_SALT is missing.
     You can generate one by calling: mix phx.gen.secret
     """
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,3 +21,7 @@ config :voomex, Oban,
 
 # Print only warnings and errors during test
 config :logger, level: :warn
+
+if File.exists?("config/#{Mix.env()}.secret.exs") do
+  import_config("#{Mix.env()}.secret.exs")
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,6 +11,7 @@ config :voomex, Voomex.SMPP,
   callback_module: Voomex.SMPP.Mock
 
 config :voomex, Voomex.Repo,
+  url: System.get_env("DATABASE_URL"),
   database: "voomex_test",
   hostname: "localhost"
 


### PR DESCRIPTION
And...
- add some docs about DB setup
- setup DB on CircleCI

I put the following content into `dev.secret.exs` and `test.secret.exs` and things work locally for me:
```
import Config

config :voomex, Voomex.Repo, socket_dir: "/var/run/postgresql"
```