### PR TITLE
Modify the connection process to allow for many of them

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,16 +14,30 @@ config :voomex, VoomexWeb.Endpoint,
 config :voomex, Voomex.SMPP,
   start: true,
   callback_module: Voomex.SMPP.Implementation,
-  host: "localhost",
-  port: 2775,
-  transport_name: "almadar_smpp_transport_10020",
-  system_id: "smppclient1",
-  password: "password",
-  source_addr: "12345",
   source_ton: 1,
   source_npi: 1,
   dest_ton: 1,
-  dest_npi: 1
+  dest_npi: 1,
+  connections: [
+    %{
+      mno: "almadar",
+      source_addr: "10020",
+      host: "localhost",
+      port: 2775,
+      transport_name: "almadar_smpp_transport_10020",
+      system_id: "smppclient1",
+      password: "password"
+    },
+    %{
+      mno: "libyana",
+      source_addr: "10020",
+      host: "localhost",
+      port: 2776,
+      transport_name: "libyana_smpp_transport_10020",
+      system_id: "smppclient1",
+      password: "password"
+    }
+  ]
 
 config :voomex, Voomex.RapidSMS, url: "http://localhost:8002/backend/vumi-http/"
 

--- a/lib/voomex/smpp.ex
+++ b/lib/voomex/smpp.ex
@@ -3,23 +3,29 @@ defmodule Voomex.SMPP do
   Voomex.SMPP handles the interaction between the web API and the mobile network operator (MNO).
   """
 
-  @callback send_submit_sm(submit_sm :: map()) :: :ok
+  @callback send_submit_sm(mno :: String.t(), from_addr :: String.t(), submit_sm :: map()) :: :ok
 
-  @callback send_to_mno(dest_addresses :: [String.t()], message :: String.t()) :: :ok
+  @callback send_to_mno(
+              mno :: String.t(),
+              from_addr :: String.t(),
+              dest_addresses :: [String.t()],
+              message :: String.t()
+            ) ::
+              :ok
 
   @callback_module Application.get_env(:voomex, Voomex.SMPP)[:callback_module]
 
   @doc """
   Send a message to the destination address
   """
-  def send_submit_sm(submit_sm) do
-    @callback_module.send_submit_sm(submit_sm)
+  def send_submit_sm(mno, from_addr, submit_sm) do
+    @callback_module.send_submit_sm(mno, from_addr, submit_sm)
   end
 
   @doc """
   Send a message to the destination address
   """
-  def send_to_mno(dest_addresses, message) do
-    @callback_module.send_to_mno(dest_addresses, message)
+  def send_to_mno(mno, from_addr, dest_addresses, message) do
+    @callback_module.send_to_mno(mno, from_addr, dest_addresses, message)
   end
 end

--- a/lib/voomex/smpp/implementation.ex
+++ b/lib/voomex/smpp/implementation.ex
@@ -8,10 +8,10 @@ defmodule Voomex.SMPP.Implementation do
   alias Voomex.SMPP.Connection
 
   @impl true
-  def send_submit_sm(submit_sm) do
-    case Voomex.SMPP.Monitor.booted?() do
+  def send_submit_sm(mno, from_addr, submit_sm) do
+    case Voomex.SMPP.Monitor.booted?(mno, from_addr) do
       true ->
-        SMPPEX.Session.send_pdu(Connection, submit_sm)
+        SMPPEX.Session.send_pdu(Connection.name(mno, from_addr), submit_sm)
 
       false ->
         {:error, :not_booted}
@@ -19,9 +19,9 @@ defmodule Voomex.SMPP.Implementation do
   end
 
   @impl true
-  def send_to_mno(dest_addresses, message) do
+  def send_to_mno(mno, from_addr, dest_addresses, message) do
     Enum.each(dest_addresses, fn dest_addr ->
-      %{dest_addr: dest_addr, message: message}
+      %{dest_addr: dest_addr, message: message, mno: mno, from_addr: from_addr}
       |> Voomex.SMPP.Worker.new()
       |> Oban.insert()
     end)

--- a/lib/voomex/smpp/mock.ex
+++ b/lib/voomex/smpp/mock.ex
@@ -6,12 +6,12 @@ defmodule Voomex.SMPP.Mock do
   @behaviour Voomex.SMPP
 
   @impl true
-  def send_submit_sm(submit_sm) do
-    send(self(), {:send_submit_sm, submit_sm})
+  def send_submit_sm(mno, from_addr, submit_sm) do
+    send(self(), {:send_submit_sm, mno, from_addr, submit_sm})
   end
 
   @impl true
-  def send_to_mno(dest_addr, message) do
-    send(self(), {:send_to_mno, dest_addr, message})
+  def send_to_mno(mno, from_addr, dest_addr, message) do
+    send(self(), {:send_to_mno, mno, from_addr, dest_addr, message})
   end
 end

--- a/lib/voomex/smpp/tether_supervisor.ex
+++ b/lib/voomex/smpp/tether_supervisor.ex
@@ -16,12 +16,17 @@ defmodule Voomex.SMPP.TetherSupervisor do
   alias Voomex.SMPP.Connection
 
   @doc false
-  def start_connection() do
+  def name(connection) do
+    {:via, Registry, {Voomex.SMPP.TetherRegistry, {connection.mno, connection.source_addr}}}
+  end
+
+  @doc false
+  def start_connection(connection) do
     config = Application.get_env(:voomex, Voomex.SMPP)
 
     case config[:start] do
       true ->
-        DynamicSupervisor.start_child(__MODULE__, {Connection, []})
+        DynamicSupervisor.start_child(name(connection), {Connection, connection})
 
       false ->
         {:error, :not_starting}

--- a/lib/voomex/smpp/worker.ex
+++ b/lib/voomex/smpp/worker.ex
@@ -11,10 +11,15 @@ defmodule Voomex.SMPP.Worker do
   @impl true
   def perform(args, _job), do: perform(args)
 
-  def perform(%{"dest_addr" => dest_addr, "message" => message}) do
+  def perform(%{
+        "dest_addr" => dest_addr,
+        "message" => message,
+        "mno" => mno,
+        "from_addr" => from_addr
+      }) do
     submit_sm = PDU.submit_sm(dest_addr, message)
 
     # TODO validate what comes back from this, raise an error if there is one
-    SMPP.send_submit_sm(submit_sm)
+    SMPP.send_submit_sm(mno, from_addr, submit_sm)
   end
 end

--- a/lib/voomex_web/controllers/sms_controller.ex
+++ b/lib/voomex_web/controllers/sms_controller.ex
@@ -3,10 +3,15 @@ defmodule VoomexWeb.SMSController do
 
   alias Voomex.SMPP
 
-  def send(conn, %{"to_addr" => to_addr, "content" => content})
+  def send(conn, %{
+        "to_addr" => to_addr,
+        "content" => content,
+        "mno" => mno,
+        "from_addr" => from_addr
+      })
       when is_list(to_addr) do
     # TODO: may also need "in_reply_to" and "metadata.rapidsms_msg_id"
-    SMPP.send_to_mno(to_addr, content)
+    SMPP.send_to_mno(mno, from_addr, to_addr, content)
 
     json(conn, :ok)
   end

--- a/lib/voomex_web/router.ex
+++ b/lib/voomex_web/router.ex
@@ -24,7 +24,7 @@ defmodule VoomexWeb.Router do
   scope "/api/v1", VoomexWeb do
     pipe_through :api
 
-    post "/send", SMSController, :send
+    post "/send/:mno", SMSController, :send
   end
 
   if Mix.env() == :dev do

--- a/test/voomex/smpp/worker_test.exs
+++ b/test/voomex/smpp/worker_test.exs
@@ -5,9 +5,14 @@ defmodule Voomex.SMPP.WorkerTest do
 
   describe "sending a message" do
     test "successfully" do
-      Worker.perform(%{"dest_addr" => "1231231234", "message" => "Hello"})
+      Worker.perform(%{
+        "dest_addr" => "1231231234",
+        "message" => "Hello",
+        "mno" => "my_mno",
+        "from_addr" => "10020"
+      })
 
-      assert_received {:send_submit_sm, pdu}
+      assert_received {:send_submit_sm, "my_mno", "10020", pdu}
 
       assert pdu.mandatory.short_message == "Hello"
     end

--- a/test/voomex_web/controllers/sms_controller_test.exs
+++ b/test/voomex_web/controllers/sms_controller_test.exs
@@ -5,29 +5,31 @@ defmodule VoomexWeb.SMSControllerTest do
     test "successful", %{conn: conn} do
       data = %{
         "to_addr" => ["12345", "23456"],
-        "content" => "Hello, world"
+        "content" => "Hello, world",
+        "from_addr" => "10020"
       }
 
-      conn = post(conn, Routes.sms_path(conn, :send), data)
+      conn = post(conn, Routes.sms_path(conn, :send, "my_mno"), data)
 
       assert json_response(conn, 200) == "ok"
 
-      assert_received {:send_to_mno, ["12345", "23456"], "Hello, world"}
+      assert_received {:send_to_mno, "my_mno", "10020", ["12345", "23456"], "Hello, world"}
     end
 
     test "failure when to_addr is not a list", %{conn: conn} do
       data = %{
         "to_addr" => "12345",
-        "content" => "Hello, world"
+        "content" => "Hello, world",
+        "from_addr" => "10020"
       }
 
-      conn = post(conn, Routes.sms_path(conn, :send), data)
+      conn = post(conn, Routes.sms_path(conn, :send, "my_mno"), data)
 
       assert json_response(conn, 422) == "error"
     end
 
     test "failure when missing parameters", %{conn: conn} do
-      conn = post(conn, Routes.sms_path(conn, :send), %{})
+      conn = post(conn, Routes.sms_path(conn, :send, "my_mno"), %{})
 
       assert json_response(conn, 422) == "error"
     end


### PR DESCRIPTION
- Registers processes with the mno/short code
- Boots connections based on configuration
- The SMS send API now requires an MNO and will send to that MNO based
  on the `from_addr` that matches a booted `source_addr`