### PR TITLE
Connect to multiple RapidSMS URLs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,6 @@ config :voomex, Voomex.SMPP,
       source_addr: "10020",
       host: "localhost",
       port: 2775,
-      transport_name: "almadar_smpp_transport_10020",
       system_id: "smppclient1",
       password: "password"
     },
@@ -33,13 +32,22 @@ config :voomex, Voomex.SMPP,
       source_addr: "10020",
       host: "localhost",
       port: 2776,
-      transport_name: "libyana_smpp_transport_10020",
       system_id: "smppclient1",
       password: "password"
     }
   ]
 
-config :voomex, Voomex.RapidSMS, url: "http://localhost:8002/backend/vumi-http/"
+config :voomex, Voomex.RapidSMS,
+  connections: [
+    %{
+      mno: "almadar",
+      url: "http://localhost:8002/backend/vumi-almadar/"
+    },
+    %{
+      mno: "libyana",
+      url: "http://localhost:8002/backend/vumi-libyana/"
+    }
+  ]
 
 config :voomex, Oban,
   repo: Voomex.Repo,

--- a/lib/voomex/rapidsms/worker.ex
+++ b/lib/voomex/rapidsms/worker.ex
@@ -5,14 +5,11 @@ defmodule Voomex.RapidSMS.Worker do
 
   use Oban.Worker, queue: :to_rapidsms
 
-  alias Voomex.RapidSMS
-
   @impl true
   def perform(args, _job), do: perform(args)
 
   def perform(args) do
-    args
-    |> Jason.encode!()
-    |> RapidSMS.post_request()
+    request_body = Voomex.RapidSMS.prepare_body(args)
+    Mojito.post(args["url"], [{"content-type", "application/json"}], request_body)
   end
 end

--- a/lib/voomex/smpp/connection.ex
+++ b/lib/voomex/smpp/connection.ex
@@ -80,7 +80,7 @@ defmodule Voomex.SMPP.Connection do
   def handle_pdu(pdu, state) do
     case SMPPEX.Pdu.command_name(pdu) do
       :deliver_sm ->
-        RapidSMS.send_to_rapidsms(pdu)
+        RapidSMS.send_to_rapidsms(pdu, state.connection.mno)
 
       _ ->
         Logger.info("Got unhandled PDU: #{inspect(pdu)}")

--- a/lib/voomex/smpp/monitor.ex
+++ b/lib/voomex/smpp/monitor.ex
@@ -71,7 +71,7 @@ defmodule Voomex.SMPP.Monitor do
     case TetherSupervisor.start_connection(connection) do
       {:ok, pid} ->
         Process.link(pid)
-        Logger.debug("Connected to MNO", tag: :smpp)
+        Logger.debug("Connected to MNO: #{connection.mno}", tag: :smpp)
 
         {:noreply, update_connection_pid(state, connection, pid)}
 

--- a/lib/voomex/smpp/supervisor.ex
+++ b/lib/voomex/smpp/supervisor.ex
@@ -19,7 +19,7 @@ defmodule Voomex.SMPP.Supervisor do
     children =
       Enum.map(connections, fn connection ->
         Supervisor.child_spec({TetherSupervisor, [name: TetherSupervisor.name(connection)]},
-          id: connection.transport_name
+          id: "#{connection.mno}_smpp_transport_#{connection.source_addr}"
         )
       end)
 

--- a/test/voomex/rapidsms_test.exs
+++ b/test/voomex/rapidsms_test.exs
@@ -3,8 +3,8 @@ defmodule Voomex.RapidSMS.Test do
 
   alias Voomex.RapidSMS
 
-  describe "pdu_to_request" do
-    test "sets expected values" do
+  describe "parse_pdu" do
+    test "gets expected values from pdu" do
       pdu = %{
         mandatory: %{
           source_addr: "12345",
@@ -13,7 +13,7 @@ defmodule Voomex.RapidSMS.Test do
         }
       }
 
-      request = RapidSMS.pdu_to_request(pdu)
+      request = RapidSMS.parse_pdu(pdu)
 
       assert request.from_addr == "12345"
       assert request.to_addr == "54321"


### PR DESCRIPTION
* Adds a list of `connections` to the RapidSMS config, mirroring how we set up SMPP connections.
* Adds `mno` to the RapidSMS calls so that the proper RapidSMS backend gets used.
* Removes `transport_name` with a calculated value
