### PR TITLE
Add config to allow DB tests and add 1 test (proof of concept)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -13,7 +13,8 @@ config :voomex, Voomex.SMPP,
 config :voomex, Voomex.Repo,
   url: System.get_env("DATABASE_URL"),
   database: "voomex_test",
-  hostname: "localhost"
+  hostname: "localhost",
+  pool: Ecto.Adapters.SQL.Sandbox
 
 config :voomex, Oban,
   crontab: false,

--- a/lib/voomex/rapidsms.ex
+++ b/lib/voomex/rapidsms.ex
@@ -9,9 +9,7 @@ defmodule Voomex.RapidSMS do
   Send the PDU to RapidSMS
   """
   def send_to_rapidsms(pdu, mno) do
-    parse_pdu(pdu)
-    |> Map.put(:mno, mno)
-    |> Map.put(:url, get_url(mno))
+    parse_pdu_and_mno(pdu, mno)
     |> Voomex.RapidSMS.Worker.new()
     |> Oban.insert()
   end
@@ -19,11 +17,13 @@ defmodule Voomex.RapidSMS do
   @doc """
   Parse the PDU and pull out the data that we need, named by the keys that RapidSMS expects
   """
-  def parse_pdu(pdu) do
+  def parse_pdu_and_mno(pdu, mno) do
     %{
       content: pdu.mandatory.short_message,
       from_addr: pdu.mandatory.source_addr,
-      to_addr: pdu.mandatory.destination_addr
+      to_addr: pdu.mandatory.destination_addr,
+      mno: mno,
+      url: get_url(mno)
     }
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Voomex.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
       deps: deps()
     ]
   end
@@ -48,6 +49,20 @@ defmodule Voomex.MixProject do
       {:smppex, github: "caktus/smppex", branch: "add-telemetry"},
       {:telemetry_poller, "~> 0.4"},
       {:telemetry_metrics, "~> 0.4"}
+    ]
+  end
+
+  # Aliases are shortcuts or tasks specific to the current project.
+  # For example, to create, migrate and run the seeds file at once:
+  #
+  #     $ mix ecto.setup
+  #
+  # See the documentation for `Mix` for more info on aliases.
+  defp aliases do
+    [
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.reset": ["ecto.drop", "ecto.setup"],
+      test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,6 @@
 ExUnit.start()
+:ok = Ecto.Adapters.SQL.Sandbox.checkout(Voomex.Repo)
+# Marking the DB connection as shared means other processes (such as Oban) can use it,
+# but means that we cannot use async tests. There are workaround if we want to change
+# that https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.Sandbox.html#module-allowances
+Ecto.Adapters.SQL.Sandbox.mode(Voomex.Repo, {:shared, self()})


### PR DESCRIPTION
Config taken mostly from here: https://hexdocs.pm/ecto/testing-with-ecto.html
But things still weren't working since our DB is hit by another process (The oban worker), so I learned more about working with that scenario here: https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.Sandbox.html#module-allowances
