### PR TITLE
Split long messages and include a UDH header

### DIFF
--- a/lib/voomex/smpp/pdu.ex
+++ b/lib/voomex/smpp/pdu.ex
@@ -18,8 +18,22 @@ defmodule Voomex.SMPP.PDU do
   end
 
   @doc """
-  Create a `submit_sm` message with configured values
+  Return `submit_sm` PDU(s)
+
+  If the message is long, the 3rd param should be a list of parts and we'll set the
+  :esm_class flag to mark it as a multipart message, returning a list of PDUs.
+
+  If the message is not long, the 3rd param should be a single binary message, and we'll
+  return a single PDU.
   """
+  def submit_sm(connection, dest_addr, parts) when is_list(parts) do
+    Enum.map(parts, fn message ->
+      submit_sm(connection, dest_addr, message)
+      # esm_class=0x40 signifies multipart
+      |> SMPPEX.Pdu.set_mandatory_field(:esm_class, 0x40)
+    end)
+  end
+
   def submit_sm(connection, dest_addr, message) do
     SMPPEX.Pdu.Factory.submit_sm(
       source(connection),

--- a/test/voomex/smpp/pdu_test.exs
+++ b/test/voomex/smpp/pdu_test.exs
@@ -20,5 +20,16 @@ defmodule Voomex.SMPP.PDUTest do
       assert pdu.mandatory.source_addr_ton == 2
       assert pdu.mandatory.source_addr_npi == 3
     end
+
+    test "returns multiple PDUs if multiple parts present" do
+      connection = %Connection{}
+      pdu_list = PDU.submit_sm(connection, "19195551212", ["Test", " message"])
+
+      assert length(pdu_list) == 2
+
+      for pdu <- pdu_list do
+        assert pdu.mandatory.esm_class == 0x40
+      end
+    end
   end
 end


### PR DESCRIPTION
Use [SMPPEX function](https://hexdocs.pm/smppex/SMPPEX.Pdu.Multipart.html#split_message/3) to split messages longer than 130 bytes (value taken from [Vumi](https://github.com/praekeltfoundation/vumi/blob/develop/vumi/transports/smpp/smpp_service.py#L288)) into parts, with each part having the proper [UDH header](https://en.wikipedia.org/wiki/Concatenated_SMS#Sending_a_concatenated_SMS_using_a_User_Data_Header)