### PR TITLE
Libya configurations

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,10 +18,6 @@ config :voomex, Voomex.SMPP,
     %{
       mno: "almadar",
       source_addrs: ["10020", "10030"],
-      source_ton: 1,
-      source_npi: 1,
-      dest_ton: 1,
-      dest_npi: 1,
       host: "localhost",
       port: 2775,
       system_id: "smppclient1",
@@ -30,14 +26,12 @@ config :voomex, Voomex.SMPP,
     %{
       mno: "libyana",
       source_addrs: ["10020", "10030"],
-      source_ton: 1,
-      source_npi: 1,
-      dest_ton: 1,
-      dest_npi: 1,
       host: "localhost",
       port: 2776,
       system_id: "smppclient1",
-      password: "password"
+      password: "password",
+      dest_ton: 0,
+      service_type: "www"
     }
   ]
 

--- a/lib/voomex/rapidsms.ex
+++ b/lib/voomex/rapidsms.ex
@@ -25,6 +25,18 @@ defmodule Voomex.RapidSMS do
       mno: mno,
       url: get_url(mno)
     }
+    |> map_to_addr()
+  end
+
+  @doc """
+  Libyana currently sets to_addr to 150 instead of 15015, so we map it properly.
+  """
+  def map_to_addr(%{mno: "libyana", to_addr: "150"} = args) do
+    %{args | to_addr: "15015"}
+  end
+
+  def map_to_addr(args) do
+    args
   end
 
   @doc """

--- a/lib/voomex/reporters/smppex_reporter.ex
+++ b/lib/voomex/reporters/smppex_reporter.ex
@@ -11,7 +11,18 @@ defmodule Voomex.SMPPEXReporter do
     ]
   end
 
-  def handle_event([:smppex, :session, :handle_resp, :enquire_link_resp], _measure, _metadata, _) do
-    Logger.info("SMPP connection received an enquire_link response", type: :smpp)
+  def handle_event(
+        [:smppex, :session, :handle_resp, :enquire_link_resp],
+        _measure,
+        %{pdu: pdu},
+        _
+      ) do
+    pdu_map =
+      Map.from_struct(pdu)
+      # change command_id to more readable command_name
+      |> Map.put(:command_name, SMPPEX.Pdu.command_name(pdu))
+      |> Map.drop([:command_id, :ref])
+
+    Logger.info("SMPP #{inspect(pdu_map)}", type: :smpp)
   end
 end

--- a/lib/voomex/smpp/connection.ex
+++ b/lib/voomex/smpp/connection.ex
@@ -90,7 +90,7 @@ defmodule Voomex.SMPP.Connection do
   end
 
   @impl true
-  def handle_info(:bind, state = %{connection: connection}) do
+  def handle_info(:bind, %{connection: connection} = state) do
     opts = %{
       # Using SMPP version 3.4
       interface_version: 0x34

--- a/lib/voomex/smpp/pdu.ex
+++ b/lib/voomex/smpp/pdu.ex
@@ -40,5 +40,7 @@ defmodule Voomex.SMPP.PDU do
       destination(connection, dest_addr),
       message
     )
+    |> SMPPEX.Pdu.set_mandatory_field(:service_type, connection.service_type)
+    |> SMPPEX.Pdu.set_mandatory_field(:data_coding, connection.data_coding)
   end
 end


### PR DESCRIPTION
Add some logging and all of the libya-specific configurations that I think I will need for setting up Libyana and Al-Madar (not going to worry about Thuraya yet)

* Set defaults for SMPP-specific connection parameters in connection.ex
* Add the ability to configure `data_coding`, `service_type`, frequency of enquire links with `enquire_link_limit`
* Log incoming and outgoing messages
* Log more detail in enquire_link_resp (Still can't seem to log the MNO with this set up...)
* Update the connection struct with the PID as soon as we know it
* Encode the message as utf-16be (probably should allow this to be configured... but all our MNOs expect this for now)
* Also libyana incorrectly sets the to_addr to 150, so map it back to 15015 before sending to RapidSMS