### PR TITLE
Switch back to single source_addr per connection

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,7 +17,15 @@ config :voomex, Voomex.SMPP,
   connections: [
     %{
       mno: "almadar",
-      source_addrs: ["10020", "10030"],
+      source_addr: "10020",
+      host: "localhost",
+      port: 2775,
+      system_id: "smppclient1",
+      password: "password"
+    },
+    %{
+      mno: "almadar",
+      source_addr: "10040",
       host: "localhost",
       port: 2775,
       system_id: "smppclient1",
@@ -25,7 +33,7 @@ config :voomex, Voomex.SMPP,
     },
     %{
       mno: "libyana",
-      source_addrs: ["10020", "10030"],
+      source_addr: "10020",
       host: "localhost",
       port: 2776,
       system_id: "smppclient1",

--- a/lib/voomex/smpp/connection.ex
+++ b/lib/voomex/smpp/connection.ex
@@ -27,22 +27,6 @@ defmodule Voomex.SMPP.Connection do
             service_type: nil,
             pid: nil
 
-  @doc """
-  Turns a config connection into a internal `Connection` struct
-
-  Takes `connection.source_addrs` and maps to multiple connections each with a single `source_addr`.
-  """
-  def initialize_connection_struct(connection) do
-    Enum.map(connection.source_addrs, fn source_addr ->
-      connection =
-        connection
-        |> Map.put(:source_addr, source_addr)
-        |> Map.delete(:source_addrs)
-
-      struct(Voomex.SMPP.Connection, connection)
-    end)
-  end
-
   # External API
 
   def name(connection) do

--- a/lib/voomex/smpp/monitor.ex
+++ b/lib/voomex/smpp/monitor.ex
@@ -10,7 +10,6 @@ defmodule Voomex.SMPP.Monitor do
 
   require Logger
 
-  alias Voomex.SMPP.Connection
   alias Voomex.SMPP.TetherSupervisor
 
   @connection_boot_delay 1_500
@@ -48,7 +47,10 @@ defmodule Voomex.SMPP.Monitor do
 
     :ets.new(__MODULE__, [:set, :protected, :named_table])
 
-    connections = Enum.flat_map(opts[:connections], &Connection.initialize_connection_struct/1)
+    connections =
+      Enum.map(opts[:connections], fn connection ->
+        struct(Voomex.SMPP.Connection, connection)
+      end)
 
     Enum.each(connections, fn connection ->
       Process.send_after(self(), [:connect, :initial, connection], @connection_boot_delay)

--- a/lib/voomex/smpp/supervisor.ex
+++ b/lib/voomex/smpp/supervisor.ex
@@ -4,7 +4,6 @@ defmodule Voomex.SMPP.Supervisor do
   """
 
   use Supervisor
-  alias Voomex.SMPP.Connection
   alias Voomex.SMPP.{Monitor, TetherSupervisor}
 
   @doc false
@@ -18,9 +17,7 @@ defmodule Voomex.SMPP.Supervisor do
     connections = Keyword.get(config, :connections, [])
 
     children =
-      connections
-      |> Enum.flat_map(&Connection.initialize_connection_struct/1)
-      |> Enum.map(fn connection ->
+      Enum.map(connections, fn connection ->
         transport_name = "#{connection.mno}_smpp_transport_#{connection.source_addr}"
 
         Supervisor.child_spec({TetherSupervisor, [name: TetherSupervisor.name(connection)]},


### PR DESCRIPTION
Revert https://github.com/caktus/voomex/commit/11b07f74d876ee0ff25f699163be705daae6902e

I was wrong... each source_addr has its own system_id and password, so it makes sense to
force each connection to have a single source_addr, rather than a list of source_addrs.