### PR TITLE
Make the URL match what we have in HAproxy

### DIFF
--- a/lib/voomex_web/router.ex
+++ b/lib/voomex_web/router.ex
@@ -24,7 +24,8 @@ defmodule VoomexWeb.Router do
   scope "/api/v1", VoomexWeb do
     pipe_through :api
 
-    post "/send/:mno", SMSController, :send
+    # named 'rapidsms' to match the current libya elections set up
+    post "/rapidsms/:mno", SMSController, :send
   end
 
   if Mix.env() == :dev do


### PR DESCRIPTION
Vumi's URL is named `/.../rapidsms/:mno` so we'll match that for now, for ease of initial deployment.